### PR TITLE
update cgo binding to use C.char

### DIFF
--- a/mediainfo.go
+++ b/mediainfo.go
@@ -70,8 +70,8 @@ func toCStream(s StreamKind) C.MediaInfo_stream_C {
 
 var cEmptyString int
 
-func emptyCString() *_Ctype_char {
-	return (*_Ctype_char)(unsafe.Pointer(&cEmptyString))
+func emptyCString() *C.char {
+	return (*C.char)(unsafe.Pointer(&cEmptyString))
 }
 
 // ErrOpenFailed is returned by Open when mediainfo cannot open the file.


### PR DESCRIPTION
In go 1.12, mangled C names are no longer supported.  https://golang.org/doc/go1.12#cgo