### PR TITLE
Fix module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
-module github.com/ezoic/go-mediainfo
+module github.com/jkl1337/go-mediainfo
 
 go 1.21
-
-require github.com/jkl1337/go-mediainfo v0.0.0-20150511200448-7ab7a0f36d69

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/jkl1337/go-mediainfo v0.0.0-20150511200448-7ab7a0f36d69 h1:dmngD3Vsjicpn3luWRpNcclBmseXLTzrbGla1hWWtTE=
-github.com/jkl1337/go-mediainfo v0.0.0-20150511200448-7ab7a0f36d69/go.mod h1:b/+ODDGYLA+4Be9mtGtbT54FU0j1tGwlsERZp7Pxysw=


### PR DESCRIPTION
When merging the `go.mod` (and `go.sum`) file from @ezoic, the module had the path of the contributor instead of your repo. This made it impossible to use as a go module:

```bash
$ go mod tidy
go: finding module for package github.com/jkl1337/go-mediainfo
go: found github.com/jkl1337/go-mediainfo in github.com/jkl1337/go-mediainfo v0.0.0-20250119192919-f538c277bd43
go: foo imports
        github.com/jkl1337/go-mediainfo: github.com/jkl1337/go-mediainfo@v0.0.0-20250119192919-f538c277bd43: parsing go.mod:
        module declares its path as: github.com/ezoic/go-mediainfo
                but was required as: github.com/jkl1337/go-mediainfo
```

This merge request fixes the module path to match this repository.